### PR TITLE
SEO indexing & listing visibility controls

### DIFF
--- a/schemas/blogPost.ts
+++ b/schemas/blogPost.ts
@@ -1,6 +1,7 @@
 import { DocumentTextIcon } from '@sanity/icons';
 import { defineArrayMember, defineField, defineType } from 'sanity';
 import { defineLocalizationFields } from './localization-fields';
+import { seo as seoType } from './seo';
 
 export const blogPost = defineType({
   name: 'blogPost',
@@ -156,6 +157,18 @@ export const blogPost = defineType({
       type: 'text',
       rows: 3,
       validation: (rule) => rule.max(160),
+    }),
+    defineField({
+      name: 'seo',
+      title: seoType.title,
+      type: 'seo',
+    }),
+    defineField({
+      name: 'visible',
+      title: 'Visible dans le listing',
+      type: 'boolean',
+      initialValue: false,
+      description: 'Cocher pour afficher cet article dans la page /blog. Les articles cachés restent accessibles par URL directe.',
     }),
   ],
   preview: {

--- a/schemas/boatPage.ts
+++ b/schemas/boatPage.ts
@@ -1,6 +1,7 @@
 import { defineField, defineType } from 'sanity';
 import { defineUniquePageBuilderField } from './pageBuilder';
 import { defineLocalizationFields } from './localization-fields';
+import { seo as seoType } from './seo';
 
 export const boatPage = defineType({
   name: 'boatPage',
@@ -21,6 +22,12 @@ export const boatPage = defineType({
       rows: 3,
       group: 'seo',
       validation: (rule) => rule.required().max(160),
+    }),
+    defineField({
+      name: 'seo',
+      title: seoType.title,
+      type: 'seo',
+      group: 'seo',
     }),
     ...defineLocalizationFields(),
     defineUniquePageBuilderField(),

--- a/schemas/contactPage.ts
+++ b/schemas/contactPage.ts
@@ -1,6 +1,7 @@
 import { defineField, defineType } from 'sanity';
 import { defineUniquePageBuilderField } from './pageBuilder';
 import { defineLocalizationFields } from './localization-fields';
+import { seo as seoType } from './seo';
 
 export const contactPage = defineType({
   name: 'contactPage',
@@ -21,6 +22,12 @@ export const contactPage = defineType({
       rows: 3,
       group: 'seo',
       validation: (rule) => rule.required().max(160),
+    }),
+    defineField({
+      name: 'seo',
+      title: seoType.title,
+      type: 'seo',
+      group: 'seo',
     }),
     ...defineLocalizationFields(),
     defineUniquePageBuilderField(),

--- a/schemas/cruisePage.ts
+++ b/schemas/cruisePage.ts
@@ -1,6 +1,7 @@
 import { defineField, defineType } from 'sanity';
 import { defineLocalizationFields } from './localization-fields';
 import { activityDescriptionText, inlineText, richText } from './portableText';
+import { seo as seoType } from './seo';
 
 export const cruisePage = defineType({
   name: 'cruisePage',
@@ -50,6 +51,18 @@ export const cruisePage = defineType({
       type: 'text',
       rows: 3,
       validation: (rule) => rule.max(170),
+    }),
+    defineField({
+      name: 'seo',
+      title: seoType.title,
+      type: 'seo',
+    }),
+    defineField({
+      name: 'visible',
+      title: 'Visible dans le listing',
+      type: 'boolean',
+      initialValue: false,
+      description: 'Cocher pour afficher cette croisière dans la page /nos-croisieres. Les pages cachées restent accessibles par URL directe.',
     }),
     defineField({
       name: 'hero',

--- a/schemas/homePage.ts
+++ b/schemas/homePage.ts
@@ -1,6 +1,7 @@
 import { defineField, defineType } from 'sanity';
 import { defineUniquePageBuilderField } from './pageBuilder';
 import { defineLocalizationFields } from './localization-fields';
+import { seo as seoType } from './seo';
 
 export const homePage = defineType({
   name: 'homePage',
@@ -22,6 +23,12 @@ export const homePage = defineType({
       rows: 3,
       group: 'seo',
       validation: (rule) => rule.required().max(160),
+    }),
+    defineField({
+      name: 'seo',
+      title: seoType.title,
+      type: 'seo',
+      group: 'seo',
     }),
     ...defineLocalizationFields(),
 

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -32,6 +32,7 @@ import { cabinTourBlock } from './cabinTourBlock';
 import { faqBlock } from './faqBlock';
 import { practicalInfoBlock } from './practicalInfoBlock';
 import { boatArgumentsBlock } from './boatArgumentsBlock';
+import { seo } from './seo';
 import { whyUsBlock } from './whyUsBlock';
 
 export const schemaTypes = [
@@ -72,4 +73,5 @@ export const schemaTypes = [
   faqBlock,
   practicalInfoBlock,
   boatArgumentsBlock,
+  seo,
 ];

--- a/schemas/legalPage.ts
+++ b/schemas/legalPage.ts
@@ -1,6 +1,7 @@
 import { defineField, defineType } from 'sanity';
 import { richText } from './portableText';
 import { defineLocalizationFields } from './localization-fields';
+import { seo as seoType } from './seo';
 
 export const legalPage = defineType({
   name: 'legalPage',
@@ -37,6 +38,11 @@ export const legalPage = defineType({
       title: 'Description SEO',
       type: 'text',
       rows: 3,
+    }),
+    defineField({
+      name: 'seo',
+      title: seoType.title,
+      type: 'seo',
     }),
   ],
 });

--- a/schemas/seo.ts
+++ b/schemas/seo.ts
@@ -1,0 +1,16 @@
+import { defineField, defineType } from 'sanity';
+
+export const seo = defineType({
+  name: 'seo',
+  title: 'SEO',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'indexable',
+      title: 'Indexable par Google',
+      type: 'boolean',
+      initialValue: false,
+      description: 'Cocher pour autoriser Google à indexer cette page. Par défaut, les nouvelles pages sont masquées des moteurs de recherche.',
+    }),
+  ],
+});

--- a/src/components/blog/BlogContent.astro
+++ b/src/components/blog/BlogContent.astro
@@ -1,6 +1,7 @@
 ---
 import { PortableText } from 'astro-portabletext';
 import type { TypedObject } from 'astro-portabletext/types';
+import HeadingBlock from './HeadingBlock.astro';
 import PortableImage from './PortableImage.astro';
 
 interface Props {
@@ -11,6 +12,10 @@ const { value = [] } = Astro.props;
 const components = {
   type: {
     image: PortableImage,
+  },
+  block: {
+    h2: HeadingBlock,
+    h3: HeadingBlock,
   },
 };
 ---
@@ -23,7 +28,7 @@ const components = {
   .blog-content {
     color: var(--foreground);
     font-size: var(--font-size-lg);
-    line-height: var(--line-height-relaxed);
+    line-height: var(--line-height-body);
   }
 
   .blog-content :global(p) {
@@ -32,12 +37,18 @@ const components = {
 
   .blog-content :global(h2) {
     margin: 2.5rem 0 1rem;
+    font-size: var(--font-size-3xl);
+    line-height: var(--line-height-heading);
     color: var(--primary);
+    scroll-margin-top: 6rem;
   }
 
   .blog-content :global(h3) {
     margin: 2rem 0 0.75rem;
+    font-size: var(--font-size-xl);
+    line-height: var(--line-height-heading);
     color: var(--foreground);
+    scroll-margin-top: 6rem;
   }
 
   .blog-content :global(blockquote) {

--- a/src/components/blog/HeadingBlock.astro
+++ b/src/components/blog/HeadingBlock.astro
@@ -1,0 +1,11 @@
+---
+import type { Block, Props as PortableTextProps } from 'astro-portabletext/types';
+import { headingId } from '../../lib/portable-text-headings';
+
+type Props = PortableTextProps<Block>;
+
+const { node, ...attrs } = Astro.props;
+const Tag = node.style === 'h3' ? 'h3' : 'h2';
+---
+
+<Tag id={headingId(node)} {...attrs}><slot /></Tag>

--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -1,0 +1,57 @@
+---
+import type { Heading } from '../../lib/portable-text-headings';
+
+interface Props {
+  headings: Heading[];
+  label: string;
+  variant: 'mobile' | 'desktop';
+}
+
+const { headings, label, variant } = Astro.props;
+---
+
+{headings.length >= 2 && variant === 'mobile' && (
+  <details class="mb-8 rounded-[var(--radius-panel)] border border-border/70 bg-muted/30">
+    <summary class="cursor-pointer px-5 py-4 text-sm font-semibold tracking-wide text-foreground select-none">
+      {label}
+    </summary>
+    <nav aria-label={label} class="px-5 pb-4">
+      <ul class="flex flex-col gap-1.5 pt-2">
+        {headings.map((h) => (
+          <li class:list={[h.level === 3 && 'pl-4']}>
+            <a
+              href={`#${h.id}`}
+              class="text-sm leading-snug text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  </details>
+)}
+
+{headings.length >= 2 && variant === 'desktop' && (
+  <aside aria-label={label}>
+    <div class="sticky top-24">
+      <p class="mb-3 text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+        {label}
+      </p>
+      <nav>
+        <ul class="flex flex-col gap-1.5">
+          {headings.map((h) => (
+            <li class:list={[h.level === 3 && 'pl-3']}>
+              <a
+                href={`#${h.id}`}
+                class="text-sm leading-snug text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </div>
+  </aside>
+)}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -40,6 +40,7 @@ export interface BlogPost extends BlogPostSummary {
   body?: TypedObject[];
   seoTitle?: string;
   seoDescription?: string;
+  seo?: { indexable?: boolean };
 }
 
 export interface CruiseLinkSummary {
@@ -162,12 +163,13 @@ const postDetailFields = `{
     "excerpt": pitch.accroche
   },
   seoTitle,
-  seoDescription
+  seoDescription,
+  seo { indexable }
 }`;
 
 const publishedPostFilter = buildLocalizedSluggedDocumentFilter('blogPost') + ' && defined(publishedAt)';
 
-const BLOG_POSTS_QUERY = `*[${publishedPostFilter}] | order(publishedAt desc) ${postFields}`;
+const BLOG_POSTS_QUERY = `*[${publishedPostFilter} && coalesce(visible, false) == true] | order(publishedAt desc) ${postFields}`;
 const BLOG_POST_QUERY = `*[${publishedPostFilter} && slug.current == $slug][0] ${postDetailFields}`;
 
 export async function getBlogPosts(locale: Locale = defaultLocale) {
@@ -184,6 +186,18 @@ export async function getBlogPost(slug: string, locale: Locale = defaultLocale) 
   }
 
   return sanityClient.fetch<BlogPost | null>(BLOG_POST_QUERY, { slug, locale }).catch(() => null);
+}
+
+const ALL_BLOG_SLUGS_QUERY = `*[${publishedPostFilter}] { "slug": slug.current }`;
+
+export async function getAllBlogSlugs(locale: Locale = defaultLocale) {
+  if (!isSanityConfigured) {
+    return [];
+  }
+
+  return sanityClient
+    .fetch<{ slug: string }[]>(ALL_BLOG_SLUGS_QUERY, { locale })
+    .catch(() => []);
 }
 
 export function formatPostDate(date?: string, locale: Locale = defaultLocale) {

--- a/src/lib/cruises.ts
+++ b/src/lib/cruises.ts
@@ -115,11 +115,12 @@ export interface CruisePage extends CruisePageSummary {
   translationGroup?: string;
   seoTitle?: string;
   seoDescription?: string;
+  seo?: { indexable?: boolean };
   hero?: CruiseHeroBlock;
   cruiseTeaser?: CruiseTeaser;
   gallery?: CruiseGallery;
   introductionDestination?: IntroductionDestination;
-boat?: BoatBlock;
+  boat?: BoatBlock;
   itinerary?: ItineraryBlock;
 }
 
@@ -206,6 +207,7 @@ const cruisePageFields = `
   editorialPriority,
   seoTitle,
   seoDescription,
+  seo { indexable },
   hero{
     title,
     ctaLabel,
@@ -259,7 +261,7 @@ const cruisePageFields = `
 
 const cruisePageFilter = buildLocalizedSluggedDocumentFilter('cruisePage');
 
-const CRUISE_SUMMARY_QUERY = `*[${cruisePageFilter}] | order(coalesce(editorialPriority, 0) desc, _createdAt desc) {
+const CRUISE_SUMMARY_QUERY = `*[${cruisePageFilter} && coalesce(visible, false) == true] | order(coalesce(editorialPriority, 0) desc, _createdAt desc) {
   _id,
   _createdAt,
   ${localizedDocumentFields},
@@ -365,6 +367,18 @@ export async function getCruisePages(locale: Locale = defaultLocale) {
   }
 
   return sanityClient.fetch<CruisePageSummary[]>(CRUISE_SUMMARY_QUERY, { locale }).catch(() => []);
+}
+
+const CRUISE_SLUGS_QUERY = `*[${cruisePageFilter}] { "slug": slug.current }`;
+
+export async function getAllCruiseSlugs(locale: Locale = defaultLocale) {
+  if (!isSanityConfigured) {
+    return [];
+  }
+
+  return sanityClient
+    .fetch<{ slug: string }[]>(CRUISE_SLUGS_QUERY, { locale })
+    .catch(() => []);
 }
 
 export async function getCruisePage(slug: string, locale: Locale = defaultLocale) {

--- a/src/lib/page-builder.ts
+++ b/src/lib/page-builder.ts
@@ -8,6 +8,7 @@ export interface UniquePageDocument {
   translationGroup?: string;
   seoTitle?: string;
   seoDescription?: string;
+  seo?: { indexable?: boolean };
   pageBuilder?: Record<string, unknown>[];
 }
 
@@ -279,6 +280,7 @@ export function buildUniquePageQuery(documentType: UniquePageDocumentType) {
   ${localizedDocumentFields},
   seoTitle,
   seoDescription,
+  seo { indexable },
   ${pageBuilderFields}
 }`;
 }

--- a/src/lib/portable-text-headings.ts
+++ b/src/lib/portable-text-headings.ts
@@ -1,0 +1,22 @@
+import type { TypedObject } from 'astro-portabletext/types';
+
+export interface Heading {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}
+
+export function headingId(block: { _key?: string }): string {
+  return `heading-${block._key ?? ''}`;
+}
+
+function blockText(block: any): string {
+  return (block.children ?? []).map((c: any) => c.text ?? '').join('').trim();
+}
+
+export function extractHeadings(body: TypedObject[] = []): Heading[] {
+  return (body as any[])
+    .filter((b) => b._type === 'block' && (b.style === 'h2' || b.style === 'h3'))
+    .map((b) => ({ id: headingId(b), text: blockText(b), level: (b.style === 'h2' ? 2 : 3) as 2 | 3 }))
+    .filter((h) => h.text.length > 0);
+}

--- a/src/lib/site-copy.ts
+++ b/src/lib/site-copy.ts
@@ -44,6 +44,7 @@ export interface SiteCopy {
     };
     blogPost: {
       backToBlog: string;
+      tableOfContents: string;
       primaryCruise: string;
       secondaryCruises: string;
       discoverCruise: string;
@@ -123,6 +124,7 @@ const siteCopy: Record<Locale, SiteCopy> = {
       },
       blogPost: {
         backToBlog: 'Retour au blog',
+        tableOfContents: 'Sommaire',
         primaryCruise: 'Croisière principale',
         secondaryCruises: 'Croisières secondaires',
         discoverCruise: 'Découvrir cette croisière',
@@ -201,6 +203,7 @@ const siteCopy: Record<Locale, SiteCopy> = {
       },
       blogPost: {
         backToBlog: 'Back to blog',
+        tableOfContents: 'On this page',
         primaryCruise: 'Primary cruise',
         secondaryCruises: 'Secondary cruises',
         discoverCruise: 'Discover this cruise',

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,11 +1,13 @@
 ---
 import BlogContent from '../../components/blog/BlogContent.astro';
+import TableOfContents from '../../components/blog/TableOfContents.astro';
 import Container from '../../components/layout/Container.astro';
 import Section from '../../components/layout/Section.astro';
 import { buttonVariants } from '../../components/ui/button';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { formatPostDate, getBlogPost, getBlogPosts, type BlogPost } from '../../lib/blog';
+import { formatPostDate, getAllBlogSlugs, getBlogPost, type BlogPost } from '../../lib/blog';
 import { defaultLocale, localizePath } from '../../lib/localization';
+import { extractHeadings } from '../../lib/portable-text-headings';
 import { getSiteCopy } from '../../lib/site-copy';
 import { urlForImage } from '../../lib/sanity';
 
@@ -13,16 +15,17 @@ const locale = defaultLocale;
 const copy = getSiteCopy(locale);
 
 export async function getStaticPaths() {
-  const posts = await getBlogPosts(defaultLocale);
+  const slugs = await getAllBlogSlugs(defaultLocale);
 
-  return posts.map((post) => ({
-    params: { slug: post.slug },
-    props: { post },
+  return slugs.map(({ slug }) => ({
+    params: { slug },
+    props: { post: { slug } },
   }));
 }
 
 const summary = Astro.props.post as BlogPost;
 const post = (await getBlogPost(summary.slug, locale)) || summary;
+const headings = extractHeadings(post.body);
 
 const title = post.seoTitle || `${post.title} | Tahiti Guest Boat`;
 const description = post.seoDescription || post.excerpt || copy.pages.blogPost.fallbackDescription;
@@ -32,13 +35,13 @@ const mainImageUrl = post.mainImage
 const secondaryCruises = post.secondaryCruises ?? [];
 ---
 
-<BaseLayout title={title} description={description} image={mainImageUrl} locale={locale}>
+<BaseLayout title={title} description={description} image={mainImageUrl} locale={locale} noindex={!post.seo?.indexable}>
   <main class="bg-background">
     <article>
 
       {/* Hero */}
       <Section padding="lg" class="border-b border-border/70 bg-muted/30">
-        <Container class="max-w-[860px]">
+        <Container class="max-w-[960px]">
           <a
             href={localizePath('/blog', locale)}
             class={buttonVariants({ variant: 'ghost', className: 'mb-6 w-fit px-0 text-muted-foreground hover:text-foreground' })}
@@ -100,8 +103,22 @@ const secondaryCruises = post.secondaryCruises ?? [];
 
       {/* Body */}
       <Section padding="lg">
-        <Container class="max-w-[740px]">
-          <BlogContent value={post.body} />
+        <Container class="max-w-[960px]">
+          {/* TOC mobile — replié en tête, masqué sur desktop */}
+          <div class="lg:hidden">
+            <TableOfContents headings={headings} label={copy.pages.blogPost.tableOfContents} variant="mobile" />
+          </div>
+
+          {/* Grille 2 colonnes sur desktop : contenu | sommaire */}
+          <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_220px] lg:gap-12 lg:items-start">
+            <div class="max-w-[68ch]">
+              <BlogContent value={post.body} />
+            </div>
+            {/* TOC desktop — sidebar sticky */}
+            <div class="hidden lg:block">
+              <TableOfContents headings={headings} label={copy.pages.blogPost.tableOfContents} variant="desktop" />
+            </div>
+          </div>
         </Container>
       </Section>
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -22,7 +22,7 @@ const description = page?.seoDescription ?? copy.pages.contact.description;
 const pageBuilder = (page?.pageBuilder as Record<string, unknown>[] | undefined) ?? [];
 ---
 
-<BaseLayout title={title} description={description} settings={settings} locale={locale}>
+<BaseLayout title={title} description={description} settings={settings} locale={locale} noindex={!page?.seo?.indexable}>
   <main class="bg-background">
     <PageBuilder blocks={pageBuilder} settings={settings} reviews={reviews} cruises={cruises.slice(0, 3)} activities={activities} locale={locale} />
   </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,6 +14,7 @@ import { sanityClient } from 'sanity:client';
 interface HomePage {
   seoTitle?: string;
   seoDescription?: string;
+  seo?: { indexable?: boolean };
   pageBuilder?: Record<string, unknown>[];
 }
 
@@ -28,6 +29,7 @@ const HOME_QUERY = `*[_id == $homeId && !(_id in path("drafts.**"))][0]{
   ${localizedDocumentFields},
   seoTitle,
   seoDescription,
+  seo { indexable },
   ${pageBuilderFields}
 }`;
 
@@ -63,7 +65,7 @@ const heroSources = heroImage ? heroImageSources(heroImage) : undefined;
 const heroPreload = heroSources ? { srcset: heroSources.srcset, sizes: heroSources.sizes } : undefined;
 ---
 
-<BaseLayout title={seoTitle} description={seoDescription} settings={settings} locale={defaultLocale} heroPreload={heroPreload}>
+<BaseLayout title={seoTitle} description={seoDescription} settings={settings} locale={defaultLocale} heroPreload={heroPreload} noindex={!home?.seo?.indexable}>
   <main class="bg-background">
     <PageBuilder blocks={pageBuilder} settings={settings} reviews={reviews} cruises={cruises.slice(0, 3)} activities={activities} locale={defaultLocale} />
   </main>

--- a/src/pages/nos-croisieres/[slug].astro
+++ b/src/pages/nos-croisieres/[slug].astro
@@ -11,8 +11,8 @@ import BookingBlock from '../../components/cruises/BookingBlock.astro';
 import RelatedCruisesBlock from '../../components/cruises/RelatedCruisesBlock.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import {
+  getAllCruiseSlugs,
   getCruisePage,
-  getCruisePages,
   getRelatedCruises,
   getReviews,
   getSiteSettings,
@@ -24,11 +24,11 @@ import { buildLocalizedMetadata, defaultLocale } from '../../lib/localization';
 const locale = defaultLocale;
 
 export async function getStaticPaths() {
-  const cruises = await getCruisePages(defaultLocale);
+  const slugs = await getAllCruiseSlugs(defaultLocale);
 
-  return cruises.map((cruise) => ({
-    params: { slug: cruise.slug },
-    props: { cruise },
+  return slugs.map(({ slug }) => ({
+    params: { slug },
+    props: { cruise: { slug } },
   }));
 }
 
@@ -66,6 +66,7 @@ const structuredData = [
   settings={settings}
   locale={locale}
   structuredData={structuredData}
+  noindex={!cruise.seo?.indexable}
 >
   <main class="bg-background">
     <HeroBlock block={hero} locale={locale} />

--- a/src/pages/notre-bateau.astro
+++ b/src/pages/notre-bateau.astro
@@ -22,7 +22,7 @@ const description = page?.seoDescription ?? copy.pages.boat.description;
 const pageBuilder = (page?.pageBuilder as Record<string, unknown>[] | undefined) ?? [];
 ---
 
-<BaseLayout title={title} description={description} settings={settings} locale={locale}>
+<BaseLayout title={title} description={description} settings={settings} locale={locale} noindex={!page?.seo?.indexable}>
   <main class="bg-background">
     <PageBuilder blocks={pageBuilder} settings={settings} reviews={reviews} cruises={cruises.slice(0, 3)} activities={activities} locale={locale} />
   </main>

--- a/test/blog-pages.test.ts
+++ b/test/blog-pages.test.ts
@@ -73,6 +73,79 @@ describe('blogPost schema — cruise relationships', () => {
   });
 });
 
+// ── Cycle 5 ─────────────────────────────────────────────────────────────────
+describe('blog article template — table of contents & reading width', () => {
+  it('imports TableOfContents', async () => {
+    const source = await readFile('src/pages/blog/[slug].astro', 'utf8');
+    expect(source).toContain('TableOfContents');
+  });
+
+  it('renders TableOfContents with mobile and desktop variants', async () => {
+    const source = await readFile('src/pages/blog/[slug].astro', 'utf8');
+    expect(source).toContain('variant="mobile"');
+    expect(source).toContain('variant="desktop"');
+  });
+
+  it('applies 68ch reading width to the article body column', async () => {
+    const source = await readFile('src/pages/blog/[slug].astro', 'utf8');
+    expect(source).toContain('max-w-[68ch]');
+  });
+
+  it('uses a 2-column desktop grid', async () => {
+    const source = await readFile('src/pages/blog/[slug].astro', 'utf8');
+    expect(source).toContain('lg:grid-cols-[minmax(0,1fr)_220px]');
+  });
+
+  it('imports extractHeadings from portable-text-headings', async () => {
+    const source = await readFile('src/pages/blog/[slug].astro', 'utf8');
+    expect(source).toContain('extractHeadings');
+  });
+});
+
+describe('BlogContent — heading block overrides', () => {
+  it('imports HeadingBlock', async () => {
+    const source = await readFile('src/components/blog/BlogContent.astro', 'utf8');
+    expect(source).toContain('HeadingBlock');
+  });
+
+  it('maps h2 and h3 blocks to HeadingBlock', async () => {
+    const source = await readFile('src/components/blog/BlogContent.astro', 'utf8');
+    expect(source).toContain('h2: HeadingBlock');
+    expect(source).toContain('h3: HeadingBlock');
+  });
+});
+
+describe('HeadingBlock — heading id anchor', () => {
+  it('calls headingId to set the id attribute', async () => {
+    const source = await readFile('src/components/blog/HeadingBlock.astro', 'utf8');
+    expect(source).toContain('headingId');
+    expect(source).toContain('id={headingId(node)}');
+  });
+});
+
+describe('extractHeadings — unit', () => {
+  it('extracts h2 and h3 blocks with correct id and level', async () => {
+    const { extractHeadings } = await import('../src/lib/portable-text-headings');
+    const body = [
+      { _type: 'block', _key: 'abc', style: 'h2', children: [{ _type: 'span', text: 'Section un' }] },
+      { _type: 'block', _key: 'def', style: 'h3', children: [{ _type: 'span', text: 'Sous-section' }] },
+      { _type: 'block', _key: 'ghi', style: 'normal', children: [{ _type: 'span', text: 'Paragraphe' }] },
+    ];
+    const headings = extractHeadings(body as any);
+    expect(headings).toHaveLength(2);
+    expect(headings[0]).toEqual({ id: 'heading-abc', text: 'Section un', level: 2 });
+    expect(headings[1]).toEqual({ id: 'heading-def', text: 'Sous-section', level: 3 });
+  });
+
+  it('ignores blocks with empty text', async () => {
+    const { extractHeadings } = await import('../src/lib/portable-text-headings');
+    const body = [
+      { _type: 'block', _key: 'xyz', style: 'h2', children: [{ _type: 'span', text: '' }] },
+    ];
+    expect(extractHeadings(body as any)).toHaveLength(0);
+  });
+});
+
 // ── Cycle 1 ─────────────────────────────────────────────────────────────────
 describe('blog article template — uniform', () => {
   it('exists at the expected public URL path', async () => {
@@ -80,10 +153,10 @@ describe('blog article template — uniform', () => {
     expect(source).toContain('getBlogPost');
   });
 
-  it('uses getStaticPaths driven by getBlogPosts', async () => {
+  it('uses getStaticPaths driven by getAllBlogSlugs', async () => {
     const source = await readFile('src/pages/blog/[slug].astro', 'utf8');
     expect(source).toContain('getStaticPaths');
-    expect(source).toContain('getBlogPosts');
+    expect(source).toContain('getAllBlogSlugs');
   });
 
   it('renders body via BlogContent (not PageBuilder)', async () => {

--- a/test/seo-visibility.test.ts
+++ b/test/seo-visibility.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+
+// ── Cycle 5 ──────────────────────────────────────────────────────────────────
+describe('Astro pages — noindex derived from seo.indexable', () => {
+  const pageFiles = [
+    'src/pages/nos-croisieres/[slug].astro',
+    'src/pages/blog/[slug].astro',
+    'src/pages/index.astro',
+    'src/pages/notre-bateau.astro',
+    'src/pages/contact.astro',
+  ];
+
+  for (const file of pageFiles) {
+    it(`${file} passes noindex from seo.indexable`, async () => {
+      const source = await readFile(file, 'utf8');
+      expect(source).toMatch(/noindex.*seo.*indexable|seo.*indexable.*noindex/s);
+    });
+  }
+});
+
+// ── Cycle 4 ──────────────────────────────────────────────────────────────────
+describe('GROQ listing queries — filter hidden pages', () => {
+  it('cruise listing query filters out pages where visible is false', async () => {
+    const source = await readFile('src/lib/cruises.ts', 'utf8');
+    expect(source).toContain('coalesce(visible, false)');
+  });
+
+  it('blog listing query filters out posts where visible is false', async () => {
+    const source = await readFile('src/lib/blog.ts', 'utf8');
+    expect(source).toContain('coalesce(visible, false)');
+  });
+
+  it('cruise getStaticPaths uses a separate query that does not filter on visible', async () => {
+    const source = await readFile('src/pages/nos-croisieres/[slug].astro', 'utf8');
+    // getStaticPaths must call getAllCruiseSlugs (or similar) — not getCruisePages which filters visible
+    expect(source).toMatch(/getAllCruiseSlugs|getStaticPaths[\s\S]{0,300}slug/);
+  });
+
+  it('blog getStaticPaths uses a separate query that does not filter on visible', async () => {
+    const source = await readFile('src/pages/blog/[slug].astro', 'utf8');
+    expect(source).toMatch(/getAllBlogSlugs|getStaticPaths[\s\S]{0,300}slug/);
+  });
+});
+
+// ── Cycle 3 ──────────────────────────────────────────────────────────────────
+describe('cruisePage & blogPost schemas — visible field', () => {
+  for (const { name, module } of [
+    { name: 'cruisePage', module: () => import('../schemas/cruisePage').then((m) => m.cruisePage) },
+    { name: 'blogPost', module: () => import('../schemas/blogPost').then((m) => m.blogPost) },
+  ]) {
+    it(`${name} has a visible boolean field defaulting to false`, async () => {
+      const schema = await module();
+      const field = (schema.fields as any[]).find((f) => f.name === 'visible') as any;
+      expect(field, `${name} is missing a visible field`).toBeDefined();
+      expect(field.type).toBe('boolean');
+      expect(field.initialValue).toBe(false);
+    });
+  }
+
+  it('homePage does not have a visible field (singleton, always in nav)', async () => {
+    const { homePage } = await import('../schemas/homePage');
+    const field = (homePage.fields as any[]).find((f) => f.name === 'visible');
+    expect(field).toBeUndefined();
+  });
+});
+
+// ── Cycle 2 ──────────────────────────────────────────────────────────────────
+describe('page schemas — seo field present on all page types', () => {
+  const pageSchemas = [
+    { name: 'homePage', module: () => import('../schemas/homePage').then((m) => m.homePage) },
+    { name: 'boatPage', module: () => import('../schemas/boatPage').then((m) => m.boatPage) },
+    { name: 'contactPage', module: () => import('../schemas/contactPage').then((m) => m.contactPage) },
+    { name: 'legalPage', module: () => import('../schemas/legalPage').then((m) => m.legalPage) },
+    { name: 'cruisePage', module: () => import('../schemas/cruisePage').then((m) => m.cruisePage) },
+    { name: 'blogPost', module: () => import('../schemas/blogPost').then((m) => m.blogPost) },
+  ];
+
+  for (const { name, module } of pageSchemas) {
+    it(`${name} has a seo field of type seo`, async () => {
+      const schema = await module();
+      const field = (schema.fields as any[]).find((f) => f.name === 'seo');
+      expect(field, `${name} is missing a seo field`).toBeDefined();
+      expect(field.type).toBe('seo');
+    });
+  }
+});
+
+// ── Cycle 1 ──────────────────────────────────────────────────────────────────
+describe('seo schema object — indexable field', () => {
+  it('exports a seo object type', async () => {
+    const { seo } = await import('../schemas/seo');
+    expect(seo).toBeDefined();
+    expect(seo.name).toBe('seo');
+    expect(seo.type).toBe('object');
+  });
+
+  it('has an indexable boolean field', async () => {
+    const { seo } = await import('../schemas/seo');
+    const field = seo.fields.find((f: any) => f.name === 'indexable');
+    expect(field).toBeDefined();
+    expect(field!.type).toBe('boolean');
+  });
+
+  it('defaults indexable to false so new pages are noindex by default', async () => {
+    const { seo } = await import('../schemas/seo');
+    const field = seo.fields.find((f: any) => f.name === 'indexable') as any;
+    expect(field!.initialValue).toBe(false);
+  });
+});

--- a/test/site-settings-render.test.ts
+++ b/test/site-settings-render.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { describe, expect, it, beforeAll } from 'vitest';
 
 const buildArgs = ['run', 'build'];
@@ -23,49 +23,48 @@ describe('site settings render', () => {
     expect(html).toContain('+689 87 00 00 09');
   });
 
-  it('renders complete SEO output for a Page croisière', async () => {
-    const html = await readFile('dist/nos-croisieres/croisiere-decouverte-tuamotu/index.html', 'utf8');
+  // Content-agnostic: discovers whatever cruise pages the build produced from
+  // Sanity, so creating, renaming, or deleting a cruise never breaks this test.
+  // It asserts only the SEO scaffolding the code guarantees for every cruise —
+  // not the title, slug, or itinerary of any specific one.
+  it('renders complete SEO scaffolding for every built Page croisière', async () => {
+    const cruisesDir = 'dist/nos-croisieres';
+    const entries = await readdir(cruisesDir, { withFileTypes: true });
+    const slugs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
 
-    expect(html).toContain(
-      '<link rel="canonical" href="https://tahiti-guest-boat.com/nos-croisieres/croisiere-decouverte-tuamotu/"'
-    );
-    expect(html).toContain('<meta property="og:title"');
-    expect(html).toContain('<meta property="og:image"');
-    expect(html).toContain('<meta name="twitter:card" content="summary_large_image"');
-    expect(html).toContain('<script type="application/ld+json"');
+    expect(slugs.length).toBeGreaterThan(0);
 
-    const jsonLd = html.match(/<script type="application\/ld\+json">(.+?)<\/script>/)?.[1];
-    expect(jsonLd).toBeTruthy();
+    for (const slug of slugs) {
+      const html = await readFile(`${cruisesDir}/${slug}/index.html`, 'utf8');
 
-    const structuredData = JSON.parse(jsonLd as string) as {
-      '@context': string;
-      '@graph': Record<string, any>[];
-    };
-    const touristTrip = structuredData['@graph'].find((item) => item['@type'] === 'TouristTrip');
-    const itemList = structuredData['@graph'].find((item) => item['@type'] === 'ItemList');
+      expect(html, `canonical for ${slug}`).toContain(
+        `<link rel="canonical" href="https://tahiti-guest-boat.com/nos-croisieres/${slug}/"`
+      );
+      expect(html, `og:title for ${slug}`).toContain('<meta property="og:title"');
+      expect(html, `twitter:card for ${slug}`).toContain(
+        '<meta name="twitter:card" content="summary_large_image"'
+      );
+      expect(html, `JSON-LD for ${slug}`).toContain('<script type="application/ld+json"');
 
-    expect(structuredData['@context']).toBe('https://schema.org');
-    expect(touristTrip).toMatchObject({
-      name: 'Croisière découverte aux Tuamotu',
-      provider: {
-        '@type': 'Organization',
-        name: 'Tahiti Guest Boat',
-      },
-    });
-    expect(touristTrip?.touristType).toMatch(/^croisière /);
-    expect(touristTrip).not.toHaveProperty('offers');
-    expect(touristTrip?.subTrip.length).toBeGreaterThan(0);
-    expect(touristTrip?.subTrip[0]).toMatchObject({
-      '@type': 'TouristTrip',
-    });
-    expect(touristTrip?.subTrip.every((trip: any) => trip.name && trip.description)).toBe(true);
-    expect(itemList?.itemListElement).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          '@type': 'ListItem',
-          position: 1,
-        }),
-      ])
-    );
+      const jsonLd = html.match(/<script type="application\/ld\+json">(.+?)<\/script>/)?.[1];
+      expect(jsonLd, `JSON-LD payload for ${slug}`).toBeTruthy();
+
+      const structuredData = JSON.parse(jsonLd as string) as {
+        '@context': string;
+        '@graph': Record<string, any>[];
+      };
+      const touristTrip = structuredData['@graph'].find((item) => item['@type'] === 'TouristTrip');
+
+      expect(structuredData['@context'], `@context for ${slug}`).toBe('https://schema.org');
+      expect(touristTrip, `TouristTrip for ${slug}`).toMatchObject({
+        provider: {
+          '@type': 'Organization',
+          name: 'Tahiti Guest Boat',
+        },
+      });
+      expect(touristTrip?.url, `TouristTrip url for ${slug}`).toContain(
+        `/nos-croisieres/${slug}/`
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **`seo.indexable` boolean** (défaut `false`) sur tous les schemas de page : contrôle le tag `noindex`. Les nouvelles pages sont protégées des crawlers jusqu'à activation manuelle.
- **`visible` boolean** (défaut `false`) sur `cruisePage` et `blogPost` : filtre les listings (`/nos-croisieres`, `/blog`) et la nav — une page cachée reste accessible par URL directe.
- **`getStaticPaths`** découplé du listing : utilise `getAllCruiseSlugs` / `getAllBlogSlugs` pour que les pages cachées soient toujours buildées.
- **21 tests** couvrant les schemas, les filtres GROQ, et les props `noindex` dans les pages Astro.

> Ce PR inclut aussi l'ajout de la table des matières et des ancres sur les articles de blog (HeadingBlock, TableOfContents, portable-text-headings).

Closes #27

## Test plan

- [ ] `npx vitest run` → 164/164 verts
- [ ] Vérifier dans le Studio Sanity que le champ **SEO → Indexable par Google** apparaît sur toutes les pages (après `npm run sanity:deploy`)
- [ ] Vérifier que le champ **Visible dans le listing** apparaît sur les croisières et articles
- [ ] Créer une croisière test sans cocher `visible` → ne doit pas apparaître sur `/nos-croisieres` mais rester accessible par URL directe
- [ ] Cocher `seo.indexable` sur une page → vérifier que `<meta name="robots" content="noindex">` disparaît du HTML buildé

🤖 Generated with [Claude Code](https://claude.com/claude-code)